### PR TITLE
Update to 1.35.5 (LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.4-fpm
 
 RUN apt-get update && \
     apt-get -y install apt-transport-https git curl libmagickwand-6.q16-dev imagemagick libicu-dev \
-               libpq-dev supervisor nginx cron libzip-dev gpg && \
+               libpq-dev supervisor nginx cron libzip-dev gpg unzip && \
     rm -rf /var/lib/apt/lists/*
 
 RUN docker-php-ext-install pgsql intl zip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN docker-php-ext-install pgsql intl zip && \
     	docker-php-ext-enable apcu --ini-name 10-docker-php-ext-apcu.ini && \
     	docker-php-ext-enable apc --ini-name 20-docker-php-ext-apc.ini
 
-ARG MEDIAWIKI_VERSION_MAJOR=1.34
-ARG MEDIAWIKI_VERSION=1.34.0
+ARG MEDIAWIKI_VERSION_MAJOR=1.35
+ARG MEDIAWIKI_VERSION=1.35.5
 
 RUN curl -s -o /tmp/keys.txt https://www.mediawiki.org/keys/keys.txt && \
     curl -s -o /tmp/mediawiki.tar.gz https://releases.wikimedia.org/mediawiki/$MEDIAWIKI_VERSION_MAJOR/mediawiki-$MEDIAWIKI_VERSION.tar.gz && \
@@ -29,7 +29,8 @@ RUN curl -s -o /tmp/keys.txt https://www.mediawiki.org/keys/keys.txt && \
     rm -rf /var/www/mediawiki/w/images && \
     ln -s /images /var/www/mediawiki/w/images
 
-RUN curl -s -o /var/www/mediawiki/w/composer.phar https://getcomposer.org/composer.phar
+#RUN curl -s -o /var/www/mediawiki/w/composer.phar https://getcomposer.org/download/latest-stable/composer.phar
+RUN curl -s -o /var/www/mediawiki/w/composer.phar https://getcomposer.org/download/latest-1.x/composer.phar
 COPY config/composer.local.json /var/www/mediawiki/w/composer.local.json
 RUN cd /var/www/mediawiki/w; php ./composer.phar update --no-dev
 

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ of Mediawiki plugins using composer.
 ## Development
 
 * `docker-compose up`
-* Visit http://localhost:8080
+* Visit http://localhost:8087 and complete the installation wizard
 
 The database credentials are: host `db`, db `wiki`, username `wiki`, password `wiki`. Once
-you've created a config file, put it in `./data/config`.
+you've downloaded the config file, put it in `./data/config`.
 
 ## Updating
 
 If a mediawiki DB needs an upgrade:
 
-    docker exec -it <container> php /var/www/mediawiki/w/maintenance/update.php
+    docker-compose exec mediawiki php /var/www/mediawiki/w/maintenance/update.php
 
 Note that if the wiki is in read-only mode, you'll have to disable that, or you'll
 get a cryptic error.

--- a/config/composer.local.json
+++ b/config/composer.local.json
@@ -1,9 +1,9 @@
 {
     "require": {
         "mediawiki/sub-page-list": "1.6.*",
-        "mediawiki/semantic-media-wiki": "3.1.*",
-        "mediawiki/page-forms": "4.6.*",
-        "mediawiki/maps": "7.15.*",
+        "mediawiki/semantic-media-wiki": "3.2.*",
+        "mediawiki/page-forms": "5.3.*",
+        "mediawiki/maps": "9.0.*",
         "mediawiki/semantic-forms-select": "3.0.*",
         "pear/mail": "1.4.*",
         "pear/net_smtp": "*"


### PR DESCRIPTION
Fixes a pre-auth vuln (which I've worked around manually, so no rush here).

I've gone for 1.35 because 1.37 throws [an error](https://www.mediawiki.org/wiki/Topic:Wjn6dne3r5isn973). This requires composer 1.x. I've also tweaked the original composer URL because the latest snapshot (2.2) isn't supported by MW yet.

Also bumps some package versions.